### PR TITLE
onCreateUseCase.execute().collect is called only once.

### DIFF
--- a/feature/home/presentation/src/main/java/com/tfandkusu/graphql/viewmodel/home/HomeViewModelImpl.kt
+++ b/feature/home/presentation/src/main/java/com/tfandkusu/graphql/viewmodel/home/HomeViewModelImpl.kt
@@ -36,10 +36,15 @@ class HomeViewModelImpl @Inject constructor(
 
     override val error = ApiErrorViewModelHelper()
 
+    private var loaded = false
+
     override fun event(event: HomeEvent) {
         viewModelScope.launch {
             when (event) {
                 HomeEvent.OnCreate -> {
+                    if (loaded)
+                        return@launch
+                    loaded = true
                     onCreateUseCase.execute().collect { issues ->
                         _state.update {
                             copy(issues = issues, progress = false)

--- a/feature/home/presentation/src/test/java/com/tfandkusu/graphql/viewmodel/home/HomeViewModelTest.kt
+++ b/feature/home/presentation/src/test/java/com/tfandkusu/graphql/viewmodel/home/HomeViewModelTest.kt
@@ -71,6 +71,8 @@ class HomeViewModelTest {
         }
         val mockStateObserver = viewModel.state.mockStateObserver()
         viewModel.event(HomeEvent.OnCreate)
+        // called only once
+        viewModel.event(HomeEvent.OnCreate)
         coVerifySequence {
             mockStateObserver.onChanged(HomeState())
             onCreateUseCase.execute()


### PR DESCRIPTION
close #21

# Changes

- onCreateUseCase.execute().collect is called only once.

